### PR TITLE
Add /purge command

### DIFF
--- a/src/base/Client.js
+++ b/src/base/Client.js
@@ -13,6 +13,7 @@ class Bot extends Client {
         Intents.FLAGS.GUILDS,
         Intents.FLAGS.GUILD_MEMBERS,
         Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
         Intents.FLAGS.DIRECT_MESSAGES,
       ],
     })
@@ -31,6 +32,18 @@ class Bot extends Client {
     const guilds = await Guild.find({}).lean()
     guilds.forEach((guild) => {
       this.guildsData.set(guild.id, guild)
+      
+      // Fetch all messages from submit channels so the bot can listen for reactions
+      this.channels.fetch(guild.submitChannel).then((submitChannel) => {
+        if (submitChannel) {
+          submitChannel.messages.fetch().then((messages) => {
+            console.log(`fetched ${messages.size} messages from channel ${submitChannel.id}`)
+          })
+        }
+      }).catch((err) => {
+        console.log(`couldn't fetch messages from guild ${guild.id}'s submit channel ${submitChannel.id}:`)
+        console.log(err)
+      })
     })
   }
 

--- a/src/commands/decline.js
+++ b/src/commands/decline.js
@@ -1,5 +1,6 @@
 const Command = require('../base/Command')
 const Discord = require('discord.js')
+const { checkIfAccepted, checkIfRejected } = require('../common/utils.js')
 
 class Decline extends Command {
   constructor(client) {
@@ -40,6 +41,18 @@ class Decline extends Command {
       return i.reply(
         `'${submissionId}' is not a valid message ID from the build submit channel!`,
       )
+    }
+
+    // Check if it already got graded
+    const isAccepted = await checkIfAccepted(submissionMsg)
+    if (isAccepted) {
+      return i.reply('that one already got graded <:bonk:720758421514878998>! Use `/purge` instead')
+    }
+
+    // Check if it already got declined / purged
+    const isRejected = await checkIfRejected(submissionMsg)
+    if (isRejected) {
+      return i.reply('that one has already been rejected <:bonk:720758421514878998>!')
     }
 
     const builder = await client.users.fetch(submissionMsg.author.id)

--- a/src/commands/editpoints.js
+++ b/src/commands/editpoints.js
@@ -2,6 +2,7 @@ const Command = require('../base/Command')
 const User = require('../base/User')
 const Submission = require('../base/Submission')
 const Discord = require('discord.js')
+const { checkIfAccepted } = require('../common/utils')
 
 class EditPoints extends Command {
   constructor(client) {
@@ -47,20 +48,12 @@ class EditPoints extends Command {
       )
     }
 
-    if (!submissionMsg.reactions.cache.has('✅')) {
+    // Check if it already got reviewed
+    const isAccepted = await checkIfAccepted(submissionMsg)
+    if (!isAccepted) {
       return i.reply(
-        'that one hasnt been graded yet <:bonk:720758421514878998>!',
+        'that one hasnt been graded yet <:bonk:720758421514878998>! `/review` it first',
       )
-    } else if (submissionMsg.reactions.cache.has('✅')) {
-      if (
-        !submissionMsg.reactions.cache
-          .get('✅')
-          .users.cache.has('718691006328995890')
-      ) {
-        return i.followUp(
-          'that one hasnt been graded <:bonk:720758421514878998>!',
-        )
-      }
     }
 
     if (

--- a/src/commands/purge.js
+++ b/src/commands/purge.js
@@ -69,7 +69,16 @@ class Purge extends Command {
 
     // Update user's points
     const pointsIncrement = -originalSubmission.pointsTotal
-    const buildingCountIncrement = -((originalSubmission.smallAmt || 0) + (originalSubmission.mediumAmt || 0) + (originalSubmission.largeAmt || 0))
+    const buildingCountIncrement = (() => {
+      switch(originalSubmission.submissionType) {
+        case 'MANY':
+          return -originalSubmission.smallAmt - originalSubmission.mediumAmt - originalSubmission.largeAmt
+        case 'ONE':
+          return -1
+        default:
+          return 0
+      }
+    })()
     const roadKMsIncrement = -originalSubmission.roadKMs || 0
     const sqmIncrement = -originalSubmission.sqm || 0
     const userId = submissionMsg.author.id

--- a/src/commands/purge.js
+++ b/src/commands/purge.js
@@ -1,0 +1,105 @@
+const Command = require('../base/Command')
+const Discord = require('discord.js')
+const Submission = require('../base/Submission')
+const User = require('../base/User')
+const { checkIfRejected } = require('../common/utils')
+
+class Purge extends Command {
+  constructor(client) {
+    super(client, {
+      name: 'purge',
+      description: 'Remove a submission that has already been accepted',
+      reviewer: true,
+      args: [
+        {
+          name: 'submissionid',
+          description: 'Msg id of the submission',
+          required: true,
+          optionType: 'string',
+        },
+        {
+          name: 'feedback',
+          description: 'feedback / reason for decline',
+          required: true,
+          optionType: 'string',
+        },
+      ],
+    })
+  }
+
+  async run(i) {
+    const options = i.options
+    const client = this.client
+    const guild = client.guildsData.get(i.guild.id)
+    const submissionId = options.getString('submissionid')
+    const feedback = options.getString('feedback')
+    const submitChannel = await client.channels.fetch(guild.submitChannel)
+
+    let submissionMsg
+
+    try {
+      submissionMsg = await submitChannel.messages.fetch(submissionId)
+    } catch (e) {
+      return i.reply(`'${submissionId}' is not a valid message ID from the build submit channel!`)
+    }
+
+    // Check if it already got reviewed
+    const originalSubmission = await Submission.findOne({
+      _id: submissionId,
+    }).lean()
+    if (originalSubmission == null) {
+      // Check if it already got declined / purged
+      const isRejected = await checkIfRejected(submissionMsg)
+      if (isRejected) {
+        return i.reply('that one has already been rejected <:bonk:720758421514878998>!')
+      } else {
+        return i.reply('that one hasnt been graded yet <:bonk:720758421514878998>! Use `/decline` instead',)
+      }
+    }
+
+    await i.reply('doing stuff...')
+
+    // Delete submission from the database
+    await Submission.deleteOne({
+      _id: submissionId,
+    }).catch((err) => {
+      console.log(err)
+      return i.followUp(`The submission couldn't be deleted from the database: ${err}\n Please try again`)
+    })
+
+    // Update user's points
+    const pointsIncrement = -originalSubmission.pointsTotal
+    const buildingCountIncrement = -((originalSubmission.smallAmt || 0) + (originalSubmission.mediumAmt || 0) + (originalSubmission.largeAmt || 0))
+    const roadKMsIncrement = -originalSubmission.roadKMs || 0
+    const sqmIncrement = -originalSubmission.sqm || 0
+    const userId = submissionMsg.author.id
+    await User.updateOne(
+      { id: userId, guildId: i.guild.id },
+      { $inc: { pointsTotal: pointsIncrement, buildingCount: buildingCountIncrement, roadKMs: roadKMsIncrement, sqm: sqmIncrement } },
+      { upsert: true },
+    ).lean()
+
+    i.followUp(`PURGED SUBMISSION [Link](${submissionMsg.url})`)
+
+    // Send a DM to the user
+    const builder = await client.users.fetch(submissionMsg.author.id)
+    const dm = await builder.createDM()
+
+    const embed = new Discord.MessageEmbed()
+      .setTitle(`Your recent build submission has been removed.`)
+      .setDescription(
+        `__[Submission link](${submissionMsg.url})__\nYou can use this feedback to improve your build then resubmit it to gain points!\n\n\`${feedback}\``,
+      )
+
+    await dm.send({ embeds: [embed] }).catch((err) => {
+      return i.followUp(`${builder} has dms turned off or something went wrong while sending the dm! ${err}`)
+    })
+
+    // Remove all bot reactions, then add a '❌' reaction
+    await submissionMsg.reactions.cache.forEach((reaction) => reaction.remove(client.id))
+    await submissionMsg.react('❌')
+    return i.followUp('removed and feedback sent :weena!: `' + feedback + '`')
+  }
+}
+
+module.exports = Purge

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -10,6 +10,7 @@ const {
 } = require('../review/options')
 const rankup = require('../review/rankup')
 const Discord = require('discord.js')
+const { checkIfRejected } = require('../common/utils')
 
 class Review extends Command {
   constructor(client) {
@@ -77,19 +78,20 @@ class Review extends Command {
       )
     }
 
-    // Check if it already got reviewed
+    // Check if it already got declined / purged
+    const isRejected = await checkIfRejected(submissionMsg)
+
+    // Check if it already got accepted
     const originalSubmission = await Submission.findOne({
       _id: submissionId,
     }).lean()
 
-    if (edit && originalSubmission == null) {
-      if (originalSubmission == null) {
-        return i.reply(
-          'that one hasnt been graded yet <:bonk:720758421514878998>!',
-        )
-      }
+    if (edit && originalSubmission == null && !isRejected) {
+      return i.reply('that one hasnt been graded yet <:bonk:720758421514878998>! Use `edit=False`')
     } else if (!edit && originalSubmission) {
-      return i.reply('that one already got graded <:bonk:720758421514878998>!')
+      return i.reply('that one already got graded <:bonk:720758421514878998>! Use `edit=True`')
+    } else if (!edit && isRejected) {
+      return i.reply('that one has already been rejected <:bonk:720758421514878998>! Use `edit=True`')
     }
 
     // set variables shared by all subcommands
@@ -98,7 +100,6 @@ class Review extends Command {
     const bonus = options.getInteger('bonus') || 1
     const collaborators = options.getInteger('collaborators') || 1
     let pointsTotal
-    let increment
 
     let submissionData = {
       _id: submissionId,
@@ -114,19 +115,36 @@ class Review extends Command {
 
     // review function used by all subcommands
     async function review(reply, data, countType, countValue) {
+      if (edit && originalSubmission && originalSubmission.submissionType !== data.submissionType) {
+        return i.followUp('can\'t change submission type on edit <:bonk:720758421514878998>! Do `/purge` and then `/review` instead')
+      }
+
       try {
         // insert submission doc
-        await Submission.replaceOne({ _id: submissionId }, data, {
+        await Submission.updateOne({ _id: submissionId }, data, {
           upsert: true,
         }).lean()
 
-        if (edit) {
-          // get change in points from original submission, update user's total points
-          increment = pointsTotal - originalSubmission.pointsTotal
-
+        if (edit && originalSubmission) {
+          // get change from original submission, update user's total points and the countType field
+          const pointsIncrement = pointsTotal - originalSubmission.pointsTotal
+          const countTypeIncrement = (() => {
+            // If editing a submission with multiple buildings, get change in user's buildingCount from the submission's building counts, which are broken down by building size
+            if (data.submissionType === 'MANY') {
+              return countValue - ((originalSubmission.smallAmt || 0) + (originalSubmission.mediumAmt || 0) + (originalSubmission.largeAmt || 0))
+            } 
+            // If editing a single building, there's no need to change the buildingCount
+            else if (data.submissionType === 'ONE') {
+              return 0
+            }
+            else {
+              return countValue - originalSubmission[countType]
+            }
+          })()
+          const userId = submissionMsg.author.id
           await User.updateOne(
             { id: userId, guildId: i.guild.id },
-            { $inc: { pointsTotal: increment } },
+            { $inc: { pointsTotal: pointsIncrement, [countType]: countTypeIncrement } },
             { upsert: true },
           ).lean()
 
@@ -171,6 +189,8 @@ class Review extends Command {
               })
           }
 
+          // Remove all bot reactions, then add a '✅' reaction
+          await submissionMsg.reactions.cache.forEach((reaction) => reaction.remove(client.id))
           await submissionMsg.react('✅')
           await i.followUp(
             `SUCCESS YAY!!!<:HAOYEEEEEEEEEEAH:908834717913186414>\n\n<@${userId}> has ${reply}`,

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,0 +1,45 @@
+const { Message } = require('discord.js')
+
+/**
+ * Basically the Array.some() function, except its async
+ * @param {Array<any> | Set<any> | Iterator<any>} collection - a collection of values
+ * @param {(element: any) => Promise<boolean>} predicate - the function to test on each element in the collection
+ * @returns true if predicate(element) is true for some element in the collection and false otherwise
+ */
+async function asyncSome(collection, predicate) {
+  for (let element of collection) {
+    result = await predicate(element)
+    if (result) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Check whether a submission has been accepted
+ * @param {Message} submissionMsg - The message/post containing the user's submission
+ * @returns true if the submission has been accepted (the bot has reacted with '✅') and false otherwise
+ */
+async function checkIfAccepted(submissionMsg) {
+  const reactionCache = submissionMsg.reactions.cache.values()
+  return asyncSome(reactionCache, async (reaction) => {
+    const updatedReaction = await reaction.fetch()
+    return updatedReaction?.emoji?.name === '✅' && updatedReaction?.me
+  })
+}
+
+/**
+ * Check whether a submission has been rejected
+ * @param {Message} submissionMsg - The message/post containing the user's submission
+ * @returns true if the submission has been rejected (the bot has reacted with '❌') and false otherwise
+ */
+async function checkIfRejected(submissionMsg) {
+  const reactionCache = submissionMsg.reactions.cache.values()
+  return asyncSome(reactionCache, async (reaction) => {
+    const updatedReaction = await reaction.fetch()
+    return updatedReaction?.emoji?.name === '❌' && updatedReaction?.me
+  })
+}
+
+module.exports = { asyncSome, checkIfAccepted, checkIfRejected }

--- a/src/events/messageReactionRemove.js
+++ b/src/events/messageReactionRemove.js
@@ -1,0 +1,50 @@
+const Client = require('../base/Client.js')
+const { MessageReaction, User } = require('discord.js')
+const Submission = require('../base/Submission.js')
+const { clientId } = require('../../config.json')
+
+/**
+ * When the bot's ✅ reaction is removed from a submission, add the reaction back if the submission is still in the database
+ * @param {Client} client 
+ * @param {MessageReaction} reaction 
+ * @param {User} user 
+ * @returns 
+ */
+async function execute(client, reaction, user) {
+  let submissionMsg = reaction.message
+  if (submissionMsg.partial) {
+    try {
+      submissionMsg = await submissionMsg.fetch()
+    } catch (error) {
+      return
+    }
+  }
+
+  const guild = submissionMsg.guild
+  if (!guild) {
+    return
+  }
+  if (
+    (!client.test && guild.id == '935926834019844097') ||
+    (client.test && guild.id != '935926834019844097')
+  )
+    return
+
+  const guildData = client.guildsData.get(guild.id)
+  if (!guildData) {
+    return
+  }
+
+  if (user.id === clientId && reaction.emoji.name === '✅') {
+    const submission = await Submission.findOne({
+      _id: submissionMsg.id,
+    }).lean()
+
+    if (submission) {
+      console.log(`✅ reaction was removed from ${submissionMsg.url}. Adding it back because the submission is still in the database`)
+      await submissionMsg.react('✅')
+    }
+  }
+}
+
+module.exports = execute

--- a/src/events/messageReactionRemoveAll.js
+++ b/src/events/messageReactionRemoveAll.js
@@ -1,0 +1,40 @@
+const Client = require('../base/Client.js')
+const { Collection, MessageReaction, Message, Snowflake } = require('discord.js')
+const Submission = require('../base/Submission.js')
+
+/**
+ * When the bot's ✅ reaction is removed from a submission, add the reaction back if the submission is still in the database
+ * @param {Client} client 
+ * @param {Message} submissionMsg
+ * @param {Collection<(string|Snowflake), MessageReaction>} reactions
+ * @returns 
+ */
+async function execute(client, submissionMsg, reactions) {
+  const guild = submissionMsg.guild
+  if (!guild) {
+    return
+  }
+  if (
+    (!client.test && guild.id == '935926834019844097') ||
+    (client.test && guild.id != '935926834019844097')
+  )
+    return
+
+  const guildData = client.guildsData.get(guild.id)
+  if (!guildData) {
+    return
+  }
+
+  if (reactions.some((reaction) => reaction.emoji.name === '✅')) {
+    const submission = await Submission.findOne({
+      _id: submissionMsg.id,
+    }).lean()
+
+    if (submission) {
+      console.log(`✅ reaction was removed from ${submissionMsg.url}. Adding it back because the submission is still in the database`)
+      await submissionMsg.react('✅')
+    }
+  }
+}
+
+module.exports = execute


### PR DESCRIPTION
The /purge command allows a reviewer to remove a submission that was previously accepted. It deletes the submission from the database and removes the points from the user's point total. Purging a submission that hasn't been reviewed or has been rejected won't do anything.

Bug fixes:
- Editing a build will update the building count / land area / road length of both the submission and the user
- When checking reactions to see if the submission has been accepted/rejected, fetch the reaction since the reaction cache could be out of date

Handled some edge cases:
- Using /decline on a previously accepted submission will do nothing and tell the reviewer to use /purge instead
- Using /decline on a previously rejected submission will do nothing
- Allow reviewers to accept a previously rejected submission with /review edit=True
- Using /review edit=False on a previously rejected submission will do nothing and tell the reviewer to use /review edit=True
- When someone removes the bot's ✅ reaction, add the reaction back if the submission is stored in the database. Some commands check the reaction while others check the database to determine if a build was accepted, and this helps keep them consistent

Other changes:
- Add a /commons/utils.js file for storing reused functions
- When the bot reacts, remove all previous reactions so a submission won't have both ❌ and ✅ reactions from the bot